### PR TITLE
#14 Use context manager to log scopus queries

### DIFF
--- a/docs/tutorial/debug.rst
+++ b/docs/tutorial/debug.rst
@@ -8,15 +8,14 @@ The log file records entries in the following format:
 
 .. code-block:: yaml
    
-    24-11-16 21:47:20 - DEBUG: 
-        - Scopus API: Scopus Search
-        - View: COMPLETE
-        - Query: AU-ID(55208373700)
-        
-    24-11-16 21:47:21 - DEBUG: 
-        - Scopus API: Scopus Search
-        - View: COMPLETE
-        - Query: REF(55208373700) AND PUBYEAR BEF 2019 AND NOT AU-ID(55208373700)
+    24-11-22 10:09:49 - DEBUG: 
+        - Scopus API: Scopus Search with COMPLETE view 
+        - Query: AU-ID(55567912500)
+        - Results: 13
+    24-11-22 10:09:51 - DEBUG: 
+        - Scopus API: Scopus Search with COMPLETE view 
+        - Query: REF(55567912500) AND PUBYEAR BEF 2019 AND NOT AU-ID(55567912500)
+        - Results: <class 'SomeErrorClass'>
 
 
 For instance, you may want to refresh the query manually using `pybliometrics`.

--- a/sosia/classes/original.py
+++ b/sosia/classes/original.py
@@ -121,7 +121,7 @@ class Original(Scientist):
         self._matches = None
 
         # Create logger
-        log_path = Path(log_path) or DEFAULT_LOG
+        log_path = Path(log_path) if log_path else DEFAULT_LOG
         create_logger(log_path)
 
         # Instantiate superclass to load private variables

--- a/sosia/classes/original.py
+++ b/sosia/classes/original.py
@@ -121,8 +121,8 @@ class Original(Scientist):
         self._matches = None
 
         # Create logger
-        log_path = Path(log_path) if log_path else DEFAULT_LOG
-        create_logger(log_path)
+        log_path = log_path or DEFAULT_LOG
+        create_logger(Path(log_path))
 
         # Instantiate superclass to load private variables
         Scientist.__init__(self, self.identifier, match_year, refresh=refresh,

--- a/sosia/establishing/logger.py
+++ b/sosia/establishing/logger.py
@@ -9,7 +9,7 @@ from pybliometrics.scopus import AuthorSearch, ScopusSearch
 logger = None
 
 
-def create_logger(log_file: Union[str, Path] = None) -> None:
+def create_logger(log_file: Union[str, Path]) -> None:
     """Configure a logger."""
     global logger
 
@@ -43,20 +43,10 @@ class ScopusLogger:
         return self
 
     def __exit__(self, exc_type, exc_value, exc_tb):
-        # If no exception get nr of results
-        results = 0
         if not exc_type:
-            if self.scopus_class_name == 'Author Search':
-                results = self.scopus_obj.get_results_size()
-            elif self.scopus_class_name == 'Scopus Search':
-                if self.scopus_obj.results is None:
-                    results = 0
-                else:
-                    results = len(self.scopus_obj.results)
-            else:
-                raise ValueError(f'Unknown Scopus class: {self.scopus_class_name}')
-
+            results = self.scopus_obj.get_results_size()
+            self.view = self.scopus_obj._view
         logger.debug(
-            '\n\t- Scopus API: %s\n\t- View: %s\n\t- Query: %s\n\t- Exception: %s\n\t- Results: %d',
-            self.scopus_class_name, self.view, self.query[:255], exc_type, results
+            '\n\t- Scopus API: %s with %s view \n\t- Query: %s\n\t- Results: %s',
+            self.scopus_class_name, self.view, self.query[:255], exc_type or results
         )

--- a/sosia/establishing/logger.py
+++ b/sosia/establishing/logger.py
@@ -30,9 +30,9 @@ def create_logger(log_file: Union[str, Path]) -> None:
 
 class ScopusLogger:
     """Context manager to log scopus"""
-    def __init__(self, scopus_class_name, params):
+    def __init__(self, scopus_api, params):
         self.scopus_obj: Union[AuthorSearch, ScopusSearch]
-        self.scopus_class_name = scopus_class_name
+        self.scopus_api = scopus_api
         self.query = params.get('query')
         self.view = params.get('view', 'Default')
 
@@ -48,5 +48,5 @@ class ScopusLogger:
             self.view = self.scopus_obj._view
         logger.debug(
             '\n\t- Scopus API: %s with %s view \n\t- Query: %s\n\t- Results: %s',
-            self.scopus_class_name, self.view, self.query[:255], exc_type or results
+            self.scopus_api, self.view, self.query, exc_type or results
         )


### PR DESCRIPTION
Let's use a context manager to log scopus (and any exception). The context manager executes the scopus query in a try-except manner which enables us to always log and detect any exception.

The resulting logs look as follows:

```
24-11-20 15:25:01 - DEBUG: 
	- Scopus API: Author Search
	- View: Default
	- Query: AU-ID(55208373700)
	- Exception: None
	- Results: 1
24-11-20 15:25:01 - DEBUG: 
	- Scopus API: Scopus Search
	- View: COMPLETE
	- Query: SOURCE-ID(11600153421) AND PUBYEAR IS 2011
	- Exception: None
	- Results: 62
24-11-20 15:25:01 - DEBUG: 
```
